### PR TITLE
hypergo pass by reference output_operations need body and routingkey …

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -13,3 +13,4 @@ glom
 azure-servicebus
 azure-functions
 types-PyYAML
+click

--- a/hypergo/transform.py
+++ b/hypergo/transform.py
@@ -57,7 +57,7 @@ class Transform:
                     str_result = Utility.stringify(out_message)
                     out_storage_key = Utility.hash(str_result)
                     storage.save(out_storage_key, str_result)
-                    out_message = {"storagekey": out_storage_key}
+                    out_message = {"body": {}, "routing": out_message['routingkey'], "storagekey": out_storage_key}
                 yield out_message
 
         return wrapped_func


### PR DESCRIPTION
…as part of the message before sending it back to the bus