### PR TITLE
[DAT-745] Bugfix - null messages being sent, breaking storebyreference

### DIFF
--- a/hypergo/executor.py
+++ b/hypergo/executor.py
@@ -190,7 +190,6 @@ class Executor:
         for return_value in execution:
             output_message: MessageType = {
                 "routingkey": self.get_output_routing_key(Utility.deep_get(context, "message.routingkey")),
-                "body": None,
                 "transaction": Utility.deep_get(context, "transaction"),
             }
             output_context: ContextType = {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [tool.poetry]
 name = "hypergo"
-version = "0.3.16"
+version = "0.3.17"
 description = "Project for service bus"
 
 [tool.setuptools_scm]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = hypergo
-version = 0.3.16
+version = 0.3.17
 description = Project for service bus
 long_description_content_type = text/markdown
 

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import setup, find_packages
 # Define the setup parameters
 setup(
     name='hypergo',
-    version='0.3.16',  # Enclose the version number in quotes
+    version='0.3.17',  # Enclose the version number in quotes
     description='Project for service bus',
     long_description_content_type='text/markdown',
     packages=find_packages(),


### PR DESCRIPTION
Remove body from default message. When pydash encounters an existing key that is currently set to None, it is unable to deeply set a property there, and leaves it as None